### PR TITLE
Fix expo babel configuration error

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};


### PR DESCRIPTION
Add `babel.config.js` to fix a Babel error (`.plugins is not a valid Plugin property`) caused by a missing Babel configuration in the Expo project.

---
<a href="https://cursor.com/background-agent?bcId=bc-1594d901-3b6c-45a2-a769-fa715d490210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1594d901-3b6c-45a2-a769-fa715d490210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

