### PR TITLE
Fix expo babel configuration error

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'expo-router/babel',
+      // Ajouter d'autres plugins si nécessaire
+    ],
+  };
+};


### PR DESCRIPTION
Create `babel.config.js` to resolve the `[BABEL] .plugins is not a valid Plugin property` error during Expo bundling.

---
<a href="https://cursor.com/background-agent?bcId=bc-d34fe237-9de5-46d8-9fd9-2defdb48b75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d34fe237-9de5-46d8-9fd9-2defdb48b75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

