### PR TITLE
Fix expo babel configuration error

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};


### PR DESCRIPTION
Add `babel.config.js` to resolve the `[BABEL] .plugins is not a valid Plugin property` error during `npx expo start -c`.

---
<a href="https://cursor.com/background-agent?bcId=bc-78e48053-d60e-4807-a24f-4e21511a3149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78e48053-d60e-4807-a24f-4e21511a3149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

